### PR TITLE
Extend support for state transition with no input

### DIFF
--- a/fsm2sv
+++ b/fsm2sv
@@ -221,10 +221,14 @@ class DotVisitor:   # pylint: disable=too-few-public-methods
                 label = f"[label=\"{trans.condition}"
             mealy = ""
             if trans.mealy_outputs:
+                if trans.condition is None:
+                    label = f"[label=\""
                 mealy = " / "
                 for out, val in trans.mealy_outputs.items():
                     mealy += f"{out}={val},"
             label += mealy
+            if (trans.condition is None) and (trans.mealy_outputs):
+                label += "\"]"
             if trans.condition is not None:
                 label += "\"]"
             dump(f"{label};\n")
@@ -627,9 +631,14 @@ class FSM:   # pylint: disable=too-many-instance-attributes
                     else:
                         assert not has_direct_arc
                         has_direct_arc = True
-                        assert len(elems) == 1
+                        mealy = elems[1] if len(elems) == 2 else None
+                        mealy_outs = {}
+                        if mealy is not None:
+                            mealy_outs = self.parse_output_line(mealy)
+                        else:
+                            assert len(elems) == 1 
                         assert not elems[0].startswith(tuple(INOUT_CHARS))
-                        trans = Transition(key, elems[0], None, {})
+                        trans = Transition(key, elems[0], None, mealy_outs)
                         self.transitions.append(trans)
                 self.states[key] = State(key, idx, moore_outs)
             idx += 1


### PR DESCRIPTION
In case of a state without transition condition but with mealy outputs; the parsing is failed. 

As an example, you can see the DEFAULT state on following code. 

```yaml
transitions:
  - DEFAULT:
    - 2NDSTATE, <mealy_out0 = 3b'101, mealy_out1 = 1b'1, >
    - <moore_out0 = 2b'01> 
  - 2NDSTATE:
    - (COND), 3RDSTATE, <mealy_out0 = 3b'001, mealy_out1 = 1b'1, >
    - <moore_out0 = 2b'11> 
```

This commit extends FSM transition Case3, transition with no input, by adding the mealy outputs.