### PR TITLE
Added a newline character before each moore output in dot visitor

### DIFF
--- a/fsm2sv
+++ b/fsm2sv
@@ -207,9 +207,8 @@ class DotVisitor:   # pylint: disable=too-few-public-methods
             label = f"{state}"
             moore = ""
             if value.moore_outputs:
-                moore += "\\n"
                 for out, val in value.moore_outputs.items():
-                    moore += f"{out}={val},"
+                    moore += f"\n{out}={val},"
             label += moore
             shape = "doublecircle" if state == fsm.initial_state else "circle"
             dump(f"  {state}[label=\"{label}\",shape={shape}];\n")


### PR DESCRIPTION
Added a newline character before each moore output in dot visitor as to improve readabillity of complex state machines. Don't know if you like it aswell, but thought I would contribute it back.